### PR TITLE
✨ Add Block : Multiple Product Card components

### DIFF
--- a/src/app/(content)/blocks/[slug]/page.tsx
+++ b/src/app/(content)/blocks/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { ServicesView } from "../view/services-view";
 import { TeamView } from "../view/team-view";
 import { TestimonialGridView } from "../view/testimonial-grid-view";
 import { TestimonialSliderView } from "../view/testimonial-slider-view";
+import { ProductCard } from "../view/product-card-view";
 
 export async function generateStaticParams() {
   return blocksArr.map((element) => ({
@@ -48,6 +49,7 @@ const componentMap: Record<string, JSX.Element> = {
   "testimonial-slider": <TestimonialSliderView />,
   team: <TeamView />,
   hero: <HeroView />,
+  'product-card': <ProductCard/>
 };
 
 export default async function Page({

--- a/src/app/(content)/blocks/code-string/product-card/cover-bottom-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/cover-bottom-product-card-string.ts
@@ -1,0 +1,98 @@
+export const coverBottomProductCardString = `
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Box, Button, Stack } from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+
+export const CoverBottomProductCard = () => {
+  const product = {
+    name: "Wireless Gaming Mouse",
+    price: 59.99,
+    oldPrice: 79.99,
+    discount: "25% OFF", // optional, can be null
+    rating: 4.3,
+    image:
+      "https://images.unsplash.com/photo-1627745214193-2bcefc681524?q=80&w=465&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        width: 400,
+        height: 500,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 18px rgba(0,0,0,0.15)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Cover image (80% height) */}
+      <Box
+        sx={{
+          flex: "0 0 65%",
+          backgroundImage: \`url(\${product.image})\`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Product details (20% height) */}
+      <CardContent sx={{ flex: "0 0 20%", p: 2 }}>
+        <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            {product.oldPrice && (
+              <Typography
+                variant="body2"
+                sx={{ textDecoration: "line-through", opacity: 0.6 }}
+              >
+                $ {product.oldPrice.toFixed(2)}
+              </Typography>
+            )}
+            <Typography variant="h6" color="primary">
+              $ {product.price.toFixed(2)}
+            </Typography>
+          </Box>
+
+          {/* Rating */}
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <StarIcon sx={{ color: "#fbc02d", fontSize: 20 }} />
+            <Typography variant="body2" fontWeight="medium">
+              {product.rating}
+            </Typography>
+          </Stack>
+        </Stack>
+
+        {/* Discount label (optional) */}
+        {product.discount && (
+          <Typography
+            variant="caption"
+            sx={{
+              mt: 1,
+              display: "inline-block",
+              px: 1,
+              py: 0.3,
+              backgroundColor: "rgba(255,0,0,0.1)",
+              color: "red",
+              borderRadius: "6px",
+              fontWeight: "bold",
+            }}
+          >
+            {product.discount}
+          </Typography>
+          
+        )}
+         <Button variant="contained" sx={{ borderRadius: 20, color:'whitesmoke', marginLeft: 5, }}>
+            Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/code-string/product-card/discount-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/discount-product-card-string.ts
@@ -1,0 +1,92 @@
+export const discountProductCardString =`
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const DiscountProductCard = () => {
+  const product = {
+    name: "Noise Cancelling Headphones",
+    price: 249.99,
+    oldPrice: 349.99,
+    discount: "30% OFF",
+    image:
+      "https://plus.unsplash.com/premium_photo-1679513691641-9aedddc94f96?q=80&w=813&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: \`url(\${product.image})\`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "brightness(0.6)",
+        }}
+      />
+
+      {/* Discount badge */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 16,
+          right: 16,
+          backgroundColor: "rgba(255,0,0,0.9)",
+          color: "white",
+          px: 1.5,
+          py: 0.5,
+          borderRadius: "12px",
+          fontWeight: "bold",
+          fontSize: "0.85rem",
+        }}
+      >
+        {product.discount}
+      </Box>
+
+      {/* Bottom details */}
+      <CardContent
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          width: "100%",
+          color: "white",
+          p: 3,
+        }}
+      >
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{
+            textDecoration: "line-through",
+            opacity: 0.7,
+          }}
+        >
+          $ {product.oldPrice.toFixed(2)}
+        </Typography>
+        <Typography variant="h5" color="secondary" sx={{ mb: 2 }}>
+          $ {product.price.toFixed(2)}
+        </Typography>
+        <Button variant="contained" sx={{ borderRadius: 20, color:'whitesmoke' }}>
+          Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+
+`

--- a/src/app/(content)/blocks/code-string/product-card/full-cover-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/full-cover-product-card-string.ts
@@ -1,0 +1,72 @@
+export const fullCoverProductCardString = `
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const FullCoverProductCard = () => {
+  const product = {
+    name: "Wireless Noise-Cancelling Headphones",
+    price: 249.99,
+    image:
+      "https://plus.unsplash.com/premium_photo-1679513691641-9aedddc94f96?q=80&w=813&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: \`url(\${product.image})\`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "brightness(0.7)",
+        }}
+      />
+
+      {/* Overlay details */}
+      <CardContent
+        sx={{
+          position: "relative",
+          zIndex: 1,
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          color: "white",
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="h6" sx={{ opacity: 0.9, mb: 2 }}>
+           $ {product.price.toFixed(2)}
+        </Typography>
+        <Button
+          variant="contained"
+          sx={{
+            backgroundColor: "#ff4d4d",
+            ":hover": { backgroundColor: "#e63939" },
+            borderRadius: "20px",
+            fontWeight: "bold",
+          }}
+        >
+          Shop Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/code-string/product-card/glass-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/glass-product-card-string.ts
@@ -1,0 +1,66 @@
+export const glassProductCardString = `
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const GlassProductCard = () => {
+const product = {
+    name: "Smart Watch",
+    description: "Experience luxury and innovation with this premium Smart Watch.",
+    price: 149.99,
+    image:
+        "https://images.unsplash.com/photo-1686112594109-39e20358ff2b?q=80&w=655&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+};
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: \`url(\${product.image})\`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Glass overlay */}
+      <CardContent
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          width: "100%",
+          backdropFilter: "blur(5px) saturate(180%)",
+          backgroundColor: "rgba(255, 255, 255, 0)",
+          color: "white",
+          p: 3,
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="h6" >
+            {product.description}
+        </Typography>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          $ {product.price.toFixed(2)}
+        </Typography>
+        <Button variant="contained" color="primary" sx={{ borderRadius: 4 }}>
+          Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+`;

--- a/src/app/(content)/blocks/code-string/product-card/gradient-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/gradient-product-card-string.ts
@@ -1,0 +1,61 @@
+export const gradientProductCardString =`
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
+} from "@mui/material";
+
+export const GradientProductCard = () => {
+  const product = {
+    name: "Portable Bluetooth Speaker",
+    image:
+      "https://images.unsplash.com/photo-1587400519568-1fe0329bfb2e?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 89.99,
+  };
+
+  return (
+    <Card
+      sx={{
+        maxWidth: 300,
+        borderRadius: 4,
+        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+        color: "white",
+        overflow: "hidden",
+      }}
+    >
+      <CardMedia
+        component="img"
+        height="200"
+        image={product.image}
+        alt={product.name}
+        sx={{ objectFit: "cover" }}
+      />
+      <CardContent>
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="body1" sx={{ opacity: 0.85, mb: 2 }}>
+          $ {product.price.toFixed(2)}
+        </Typography>
+        <Button
+          variant="contained"
+          sx={{
+            backgroundColor: "rgba(255,255,255,0.2)",
+            backdropFilter: "blur(10px)",
+            color: "white",
+            ":hover": { backgroundColor: "rgba(255,255,255,0.3)" },
+          }}
+        >
+          Add to Cart
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/code-string/product-card/horizontal-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/horizontal-product-card-string.ts
@@ -1,0 +1,57 @@
+export const horizontalProductCardString = `
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
+  Stack,
+} from "@mui/material";
+
+export const HorizontalProductCard = () => {
+  const product = {
+    name: "Gaming Mechanical Keyboard",
+    image:
+      "https://plus.unsplash.com/premium_photo-1680124608003-b14fe079b955?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 129.99,
+  };
+
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        maxWidth: 500,
+        borderRadius: 3,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
+      }}
+    >
+      <CardMedia
+        component="img"
+        sx={{ width: 160, objectFit: "cover" }}
+        image={product.image}
+        alt={product.name}
+      />
+      <CardContent sx={{ flex: 1 }}>
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+           $ {product.price.toFixed(2)}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button variant="contained" size="small" color="primary">
+            Buy Now
+          </Button>
+          <Button variant="outlined" size="small" color="primary">
+            Details
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/code-string/product-card/product-showcase-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/product-showcase-card-string.ts
@@ -1,0 +1,90 @@
+export const productShowCaseCardString = `
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  CardActions,
+  Button,
+  Rating,
+  Chip,
+  Stack,
+} from "@mui/material";
+
+export const ProductShowcaseCard = () => {
+  const product = {
+    name: "Wireless Noise-Cancelling Headphones",
+    image:
+      "https://images.unsplash.com/photo-1496957961599-e35b69ef5d7c?q=80&w=872&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 199.99,
+    rating: 4.5,
+    badge: "New",
+  };
+
+  return (
+    <Card
+      sx={{
+        maxWidth: 320,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 4px 20px rgba(0,0,0,0.08)",
+      }}
+    >
+      {/* Product Image */}
+      <CardMedia
+        component="img"
+        height="220"
+        image={product.image}
+        alt={product.name}
+        sx={{
+          objectFit: "cover",
+        }}
+      />
+
+      {/* Badge */}
+      <Stack
+        direction="row"
+        justifyContent="flex-end"
+        sx={{
+          position: "absolute",
+          top: 16,
+          right: 16,
+        }}
+      >
+        <Chip
+          label={product.badge}
+          color="primary"
+          sx={{ fontWeight: "bold" }}
+        />
+      </Stack>
+
+      {/* Product Details */}
+      <CardContent>
+        <Typography variant="h6" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" gutterBottom>
+          $ {product.price.toFixed(2)}
+        </Typography>
+
+        {/* Rating */}
+        <Rating value={product.rating} precision={0.5} readOnly />
+      </CardContent>
+
+      {/* Actions */}
+      <CardActions sx={{ px: 2, pb: 2 }}>
+        <Button variant="contained" color="primary" fullWidth>
+          Add to Cart
+        </Button>
+        <Button variant="outlined" color="primary" fullWidth>
+          View Details
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/code-string/product-card/split-product-card-string.ts
+++ b/src/app/(content)/blocks/code-string/product-card/split-product-card-string.ts
@@ -1,0 +1,65 @@
+export const splitProductCardString = `
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const SplitProductCard = () => {
+  const product = {
+    name: "4K Ultra HD Smart TV",
+    price: 799.99,
+    description:
+      "Experience stunning visuals and smart features with our latest 4K Ultra HD Smart TV. Perfect for home entertainment.",
+    image:
+      "https://images.unsplash.com/photo-1601944177325-f8867652837f?q=80&w=877&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        width: 600,
+        height: 300,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Left side image */}
+      <Box
+        sx={{
+          flex: "1 1 50%",
+          backgroundImage: \`url(\${product.image})\`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Right side details */}
+      <CardContent
+        sx={{
+          flex: "1 1 50%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          p: 4,
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="h6" color="primary" gutterBottom>
+          $ {product.price.toFixed(2)}
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 3 }}>
+          {product.description}
+        </Typography>
+        <Button variant="contained" color="primary" sx={{ borderRadius: 20 }}>
+          Add to Cart
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+`;

--- a/src/app/(content)/blocks/components/product-card/cover-bottom-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/cover-bottom-product-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Box, Button, Stack } from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+
+export const CoverBottomProductCard = () => {
+  const product = {
+    name: "Wireless Gaming Mouse",
+    price: 59.99,
+    oldPrice: 79.99,
+    discount: "25% OFF", // optional, can be null
+    rating: 4.3,
+    image:
+      "https://images.unsplash.com/photo-1627745214193-2bcefc681524?q=80&w=465&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        width: 400,
+        height: 470,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 18px rgba(0,0,0,0.15)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Cover image (80% height) */}
+      <Box
+        sx={{
+          flex: "0 0 67%",
+          backgroundImage: `url(${product.image})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Product details (20% height) */}
+      <CardContent sx={{ flex: "0 0 20%", p: 2 }}>
+        <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Box>
+            {product.oldPrice && (
+              <Typography
+                variant="body2"
+                sx={{ textDecoration: "line-through", opacity: 0.6 }}
+              >
+                ${product.oldPrice.toFixed(2)}
+              </Typography>
+            )}
+            <Typography variant="h6" color="primary">
+              ${product.price.toFixed(2)}
+            </Typography>
+          </Box>
+
+          {/* Rating */}
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <StarIcon sx={{ color: "#fbc02d", fontSize: 20 }} />
+            <Typography variant="body2" fontWeight="medium">
+              {product.rating}
+            </Typography>
+          </Stack>
+        </Stack>
+
+        {/* Discount label (optional) */}
+        {product.discount && (
+          <Typography
+            variant="caption"
+            sx={{
+              mt: 1,
+              display: "inline-block",
+              px: 1,
+              py: 0.3,
+              backgroundColor: "rgba(255,0,0,0.1)",
+              color: "red",
+              borderRadius: "6px",
+              fontWeight: "bold",
+            }}
+          >
+            {product.discount}
+          </Typography>
+          
+        )}
+         <Button variant="contained" sx={{ borderRadius: 20, color:'whitesmoke', marginLeft: 5, }}>
+                  Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/discount-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/discount-product-card.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const DiscountProductCard = () => {
+  const product = {
+    name: "Noise Cancelling Headphones",
+    price: 249.99,
+    oldPrice: 349.99,
+    discount: "30% OFF",
+    image:
+      "https://plus.unsplash.com/premium_photo-1679513691641-9aedddc94f96?q=80&w=813&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: `url(${product.image})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "brightness(0.6)",
+        }}
+      />
+
+      {/* Discount badge */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 16,
+          right: 16,
+          backgroundColor: "rgba(255,0,0,0.9)",
+          color: "white",
+          px: 1.5,
+          py: 0.5,
+          borderRadius: "12px",
+          fontWeight: "bold",
+          fontSize: "0.85rem",
+        }}
+      >
+        {product.discount}
+      </Box>
+
+      {/* Bottom details */}
+      <CardContent
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          width: "100%",
+          color: "white",
+          p: 3,
+        }}
+      >
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography
+          variant="body1"
+          sx={{
+            textDecoration: "line-through",
+            opacity: 0.7,
+          }}
+        >
+          ${product.oldPrice.toFixed(2)}
+        </Typography>
+        <Typography variant="h5" color="secondary" sx={{ mb: 2 }}>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Button variant="contained" sx={{ borderRadius: 20, color:'whitesmoke' }}>
+          Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/full-cover-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/full-cover-product-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const FullCoverProductCard = () => {
+  const product = {
+    name: "Wireless Noise-Cancelling Headphones",
+    price: 249.99,
+    image:
+      "https://plus.unsplash.com/premium_photo-1679513691641-9aedddc94f96?q=80&w=813&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: `url(${product.image})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          filter: "brightness(0.7)",
+        }}
+      />
+
+      {/* Overlay details */}
+      <CardContent
+        sx={{
+          position: "relative",
+          zIndex: 1,
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          color: "white",
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="h6" sx={{ opacity: 0.9, mb: 2 }}>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Button
+          variant="contained"
+          sx={{
+            backgroundColor: "#ff4d4d",
+            ":hover": { backgroundColor: "#e63939" },
+            borderRadius: "20px",
+            fontWeight: "bold",
+          }}
+        >
+          Shop Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/glass-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/glass-product-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const GlassProductCard = () => {
+const product = {
+    name: "Smart Watch",
+    description: "Experience luxury and innovation with this premium Smart Watch.",
+    price: 149.99,
+    image:
+        "https://images.unsplash.com/photo-1686112594109-39e20358ff2b?q=80&w=655&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+};
+
+  return (
+    <Card
+      sx={{
+        position: "relative",
+        width: 350,
+        height: 450,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+      }}
+    >
+      {/* Background image */}
+      <Box
+        sx={{
+          position: "absolute",
+          inset: 0,
+          backgroundImage: `url(${product.image})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Glass overlay */}
+      <CardContent
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          width: "100%",
+          backdropFilter: "blur(5px) saturate(180%)",
+          backgroundColor: "rgba(255, 255, 255, 0)",
+          color: "white",
+          p: 3,
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="h6" >
+            {product.description}
+        </Typography>
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Button variant="contained" color="primary" sx={{ borderRadius: 4 }}>
+          Buy Now
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/gradient-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/gradient-product-card.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
+} from "@mui/material";
+
+export const GradientProductCard = () => {
+  const product = {
+    name: "Portable Bluetooth Speaker",
+    image:
+      "https://images.unsplash.com/photo-1587400519568-1fe0329bfb2e?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 89.99,
+  };
+
+  return (
+    <Card
+      sx={{
+        maxWidth: 300,
+        borderRadius: 4,
+        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+        color: "white",
+        overflow: "hidden",
+      }}
+    >
+      <CardMedia
+        component="img"
+        height="200"
+        image={product.image}
+        alt={product.name}
+        sx={{ objectFit: "cover" }}
+      />
+      <CardContent>
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="body1" sx={{ opacity: 0.85, mb: 2 }}>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Button
+          variant="contained"
+          sx={{
+            backgroundColor: "rgba(255,255,255,0.2)",
+            backdropFilter: "blur(10px)",
+            color: "white",
+            ":hover": { backgroundColor: "rgba(255,255,255,0.3)" },
+          }}
+        >
+          Add to Cart
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/horizontal-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/horizontal-product-card.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
+  Stack,
+} from "@mui/material";
+
+export const HorizontalProductCard = () => {
+  const product = {
+    name: "Gaming Mechanical Keyboard",
+    image:
+      "https://plus.unsplash.com/premium_photo-1680124608003-b14fe079b955?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 129.99,
+  };
+
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        maxWidth: 500,
+        borderRadius: 3,
+        boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
+      }}
+    >
+      <CardMedia
+        component="img"
+        sx={{ width: 160, objectFit: "cover" }}
+        image={product.image}
+        alt={product.name}
+      />
+      <CardContent sx={{ flex: 1 }}>
+        <Typography variant="h6" fontWeight="bold">
+          {product.name}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button variant="contained" size="small" color="primary">
+            Buy Now
+          </Button>
+          <Button variant="outlined" size="small" color="primary">
+            Details
+          </Button>
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/product-showcase-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/product-showcase-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+import {
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  CardActions,
+  Button,
+  Rating,
+  Chip,
+  Stack,
+} from "@mui/material";
+
+export const ProductShowcaseCard = () => {
+  const product = {
+    name: "Wireless Noise-Cancelling Headphones",
+    image:
+      "https://images.unsplash.com/photo-1496957961599-e35b69ef5d7c?q=80&w=872&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+    price: 199.99,
+    rating: 4.5,
+    badge: "New",
+  };
+
+  return (
+    <Card
+      sx={{
+        maxWidth: 320,
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 4px 20px rgba(0,0,0,0.08)",
+      }}
+    >
+      {/* Product Image */}
+      <CardMedia
+        component="img"
+        height="220"
+        image={product.image}
+        alt={product.name}
+        sx={{
+          objectFit: "cover",
+        }}
+      />
+
+      {/* Badge */}
+      <Stack
+        direction="row"
+        justifyContent="flex-end"
+        sx={{
+          position: "absolute",
+          top: 16,
+          right: 16,
+        }}
+      >
+        <Chip
+          label={product.badge}
+          color="primary"
+          sx={{ fontWeight: "bold" }}
+        />
+      </Stack>
+
+      {/* Product Details */}
+      <CardContent>
+        <Typography variant="h6" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="body1" color="text.secondary" gutterBottom>
+          ${product.price.toFixed(2)}
+        </Typography>
+
+        {/* Rating */}
+        <Rating value={product.rating} precision={0.5} readOnly />
+      </CardContent>
+
+      {/* Actions */}
+      <CardActions sx={{ px: 2, pb: 2 }}>
+        <Button variant="contained" color="primary" fullWidth>
+          Add to Cart
+        </Button>
+        <Button variant="outlined" color="primary" fullWidth>
+          View Details
+        </Button>
+      </CardActions>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/components/product-card/split-product-card.tsx
+++ b/src/app/(content)/blocks/components/product-card/split-product-card.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, Typography, Button, Box } from "@mui/material";
+
+export const SplitProductCard = () => {
+  const product = {
+    name: "4K Ultra HD Smart TV",
+    price: 799.99,
+    description:
+      "Experience stunning visuals and smart features with our latest 4K Ultra HD Smart TV. Perfect for home entertainment.",
+    image:
+      "https://images.unsplash.com/photo-1601944177325-f8867652837f?q=80&w=877&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  };
+
+  return (
+    <Card
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", md: "row" }, // stack on mobile, row on desktop
+        width: "100%",
+        maxWidth: 900,
+        height:{ xs: 'auto', md: 350 },
+        borderRadius: 4,
+        overflow: "hidden",
+        boxShadow: "0 6px 20px rgba(0,0,0,0.15)",
+        mx: "auto", // center card
+      }}
+    >
+      {/* Left side image */}
+      <Box
+        sx={{
+          flex: { xs: "1 1 auto", md: "1 1 50%" },
+          height: { xs: 220, md: "auto" }, // fixed height on mobile
+          backgroundImage: `url(${product.image})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+        }}
+      />
+
+      {/* Right side details */}
+      <CardContent
+        sx={{
+          flex: { xs: "1 1 auto", md: "1 1 50%" },
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          p: { xs: 2, md: 4 }, // smaller padding on mobile
+          textAlign: { xs: "center", md: "left" },
+        }}
+      >
+        <Typography variant="h5" fontWeight="bold" gutterBottom>
+          {product.name}
+        </Typography>
+        <Typography variant="h6" color="primary" gutterBottom>
+          ${product.price.toFixed(2)}
+        </Typography>
+        <Typography variant="body2" sx={{ mb: 3 }}>
+          {product.description}
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          sx={{ borderRadius: 20, px: 4, alignSelf: { xs: "center", md: "flex-start" } }}
+        >
+          Add to Cart
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/app/(content)/blocks/view/product-card-view.tsx
+++ b/src/app/(content)/blocks/view/product-card-view.tsx
@@ -1,0 +1,124 @@
+"use client";
+import { CodePreviewCopyWrapper } from "@/components/code-preview-copy-wrapper";
+import { CustomBreadCrumbs } from "@/components/core/breadcrumbs";
+import { PageTitle } from "@/components/core/page-title";
+import { SectionTitle } from "@/components/core/section-title";
+import { useOnThisPage } from "@/contexts/on-thispage-context";
+import { PATHS } from "@/router/paths";
+import { Box, Divider } from "@mui/material";
+import React from "react";
+import { ProductShowcaseCard } from "../components/product-card/product-showcase-card";
+import { GradientProductCard } from "../components/product-card/gradient-product-card";
+import { HorizontalProductCard } from "../components/product-card/horizontal-product-card";
+import { FullCoverProductCard } from "../components/product-card/full-cover-product-card";
+import { SplitProductCard } from "../components/product-card/split-product-card";
+import { GlassProductCard } from "../components/product-card/glass-product-card";
+import { DiscountProductCard } from "../components/product-card/discount-product-card";
+import { CoverBottomProductCard } from "../components/product-card/cover-bottom-product-card";
+import { productShowCaseCardString } from "../code-string/product-card/product-showcase-card-string";
+import { gradientProductCardString } from "../code-string/product-card/gradient-product-card-string";
+import { horizontalProductCardString } from "../code-string/product-card/horizontal-product-card-string";
+import { fullCoverProductCardString } from "../code-string/product-card/full-cover-product-card-string";
+import { splitProductCardString } from "../code-string/product-card/split-product-card-string";
+import { glassProductCardString } from "../code-string/product-card/glass-product-card-string";
+import { discountProductCardString } from "../code-string/product-card/discount-product-card-string";
+import { coverBottomProductCardString } from "../code-string/product-card/cover-bottom-product-card-string";
+
+
+const sections = [
+  {
+    id: "product-card-1",
+    title: "Basic Product Card",
+    description: "A clean product card with image, name, price, and button",
+    codeString: productShowCaseCardString,
+    preview: <ProductShowcaseCard />,
+  },
+{
+    id: "product-card-2",
+    title: "Gradient Product Card",
+    description: "Glassmorphism overlay with modern blur effect",
+    codeString: gradientProductCardString,
+    preview: <GradientProductCard />,
+  },
+{
+    id: "product-card-3",
+    title: "Side Image Product Card",
+    description: "Left side product image with full details on the right side",
+    codeString: horizontalProductCardString,
+    preview: <HorizontalProductCard />,
+  },
+ {
+    id: "product-card-4",
+    title: "Full Cover Product Card",
+    description: "Full cover image card with details inside overlay", 
+    codeString:fullCoverProductCardString,
+    preview: <FullCoverProductCard />,
+  },
+   {
+    id: "product-card-5",
+    title: "Side Image Product Card",
+    description: "Left side product image with full details on the right side",
+    codeString: splitProductCardString,
+    preview: <SplitProductCard />,
+  },
+     {
+    id: "product-card-6",
+    title: "Glass Overlay Product Card",
+    description: "Glassmorphism overlay with details inside cover card",
+    codeString: glassProductCardString,
+    preview: <GlassProductCard />,
+  },
+       {
+    id: "product-card-7",
+    title: "Discount Badge Card",
+    description: "Cover card with discount badge on the top right corner",
+    codeString: discountProductCardString,
+    preview: <DiscountProductCard />,
+  },
+  {
+    id: 'product-card-8',
+    title: "Bottom Cover Card",
+    description: "Product image covers 67% of the card height with details displayed in the remaining 33%.",
+    codeString: coverBottomProductCardString,
+    preview: <CoverBottomProductCard/>
+  }
+];
+
+export const ProductCard = () => {
+  const { setSections } = useOnThisPage();
+  React.useEffect(() => {
+    setSections([]);
+  }, [setSections]);
+  return (
+    <Box>
+      <CustomBreadCrumbs
+        pathArr={[
+          { label: "Blocks", path: PATHS.BLOCKS.PRODUCT_CARD },
+          { label: "Product card", path: "" },
+        ]}
+      />
+      <PageTitle
+        title="Product Cards"
+        description="Showcase products with modern, responsive Material UI card designs featuring price, badges, and actions."
+      />
+
+
+      <Divider sx={{ my: 4 }} />
+
+      {sections.map((section) => (
+        <Box key={section.id} sx={{ mb: 4 }}>
+          <SectionTitle
+            title={section.title}
+            description={section.description || ""}
+            id={section.id}
+          />
+
+          <CodePreviewCopyWrapper
+            codeString={section.codeString}
+            preview={section.preview}
+          />
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/router/paths.ts
+++ b/src/router/paths.ts
@@ -41,6 +41,7 @@ export const PATHS = {
     NEWSLETTER_SUBSCRIPTION: "/blocks/newsletter-subscription",
     PRICING_MENU: "/blocks/pricing-menu",
     PRICING_TABLE: "/blocks/pricing-table",
+    PRODUCT_CARD:"/blocks/product-card",
     SERVICES: "/blocks/services",
     SINGLE_PROFILE: "/blocks/single-profile",
     TEAM: "/blocks/team",


### PR DESCRIPTION
This PR introduces a collection of modern Product Card components designed with Material UI. Each variation highlights different product showcase styles, ranging from minimal cover layouts to glassmorphism overlays and discount tags.

- 🔥 What's Included
 • Cover Product Card – Full image cover with product details inside.
 • Glassmorphism Overlay Card – Stylish transparent overlay for premium look.
 • Split Product Card – Side image with details on the opposite side.
 • Discount Badge Card – Product image with a discount tag on the top-right corner.
 • Bottom Cover Card – Image covers 67–80% of height, details fill the bottom.
 • Cover + Rating Card – Product image with price, optional discount, and rating.


📸 Preview

<img width="1366" height="768" alt="productcard1" src="https://github.com/user-attachments/assets/5d095d7e-2abf-40df-9c34-2a3a69f6e82e" />
<img width="1366" height="768" alt="productcard2" src="https://github.com/user-attachments/assets/21532cc2-86df-4b29-92f0-9b8bad911193" />
<img width="1366" height="768" alt="productcard3" src="https://github.com/user-attachments/assets/5898ec3c-0f74-4464-942f-ad517aa3bbb6" />
